### PR TITLE
Fixed trait_leader_reformer

### DIFF
--- a/mod/fix_ruler_mia/common/scripted_effects/00_mia_effects.txt
+++ b/mod/fix_ruler_mia/common/scripted_effects/00_mia_effects.txt
@@ -13,6 +13,17 @@ remove_ruler_traits = {
 	if = {
 		limit = {
 			FROM = {
+				has_trait = leader_trait_reformer
+			}
+		}
+		FROM = {
+			remove_trait = leader_trait_reformer
+		}
+		set_country_flag = had_trait_reformer
+	}
+	if = {
+		limit = {
+			FROM = {
 				has_trait = trait_ruler_architectural_sense
 			}
 		}
@@ -793,6 +804,17 @@ restore_ruler_traits = {
 	}
 
 	# Restore saved old ones
+	if = {
+		limit = {
+			FROM = {
+				has_country_flag = had_trait_reformer
+			}
+		}
+		add_ruler_trait = leader_trait_reformer
+		FROM = {
+			remove_country_flag = had_trait_reformer
+		}
+	}
 	if = {
 		limit = {
 			FROM = {

--- a/mod/fix_ruler_mia/descriptor.mod
+++ b/mod/fix_ruler_mia/descriptor.mod
@@ -1,4 +1,4 @@
-version="1.3.1"
+version="1.4.0"
 tags={
 	"Fixes"
 	"Leaders"

--- a/steam-workshop/change-notes.md
+++ b/steam-workshop/change-notes.md
@@ -1,3 +1,6 @@
+Version 1.4.0
+* Fixed a bug regarding the "trait_leader_reformer" ruler trait that was incorrectly kept after changing leader class
+
 Version 1.3.1
 * Migrated to GitHub
 


### PR DESCRIPTION
It was not being removed and reapplied correctly from leader when losing their first election (oversight due to different naming of trait).